### PR TITLE
creates scripts to pull .vtt files from the gcp bucket instead of Amara

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "drive-bucket-sync": "node scripts/drive-sync.js",
     "update-media-urls": "node scripts/update-urls.js",
     "save-captions": "node scripts/save-captions.js",
-    "save-bucket-captions": "node scripts/save-bucket-captoions.js",
+    "save-bucket-captions": "node scripts/save-bucket-captions.js",
     "save-assets": "node scripts/save-assets.js"
   }
 }

--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     "drive-bucket-sync": "node scripts/drive-sync.js",
     "update-media-urls": "node scripts/update-urls.js",
     "save-captions": "node scripts/save-captions.js",
+    "save-bucket-captions": "node scripts/save-bucket-captoions.js",
     "save-assets": "node scripts/save-assets.js"
   }
 }

--- a/scripts/save-bucket-captions.js
+++ b/scripts/save-bucket-captions.js
@@ -1,0 +1,23 @@
+const { execSync, exec } = require('child_process');
+require('dotenv').config({
+  path: '.env.development',
+});
+
+const bucketFiles = execSync(`gsutil ls -r gs://${process.env.GCP_BUCKET_NAME}/`);
+// Convert string of bucket files to array of strings
+const shortenedUrls = bucketFiles.toString("utf8").split("\n").map(url => url.replace(`gs://${process.env.GCP_BUCKET_NAME}/`, ''));
+// Create newline string that python can ingest via env var
+const arrayString = shortenedUrls.join("\n");
+process.env.CAPTION_BUCKET_LIST = arrayString;
+
+exec('python scripts/save-bucket-captions.py', (error, stdout, stderr) => {
+  if (error) {
+    console.log(`error: ${error.message}`);
+    return;
+  }
+  if (stderr) {
+    console.log(`stderr: ${stderr}`);
+    return;
+  }
+  console.log(`stdout: ${stdout}`);
+});

--- a/scripts/save-bucket-captions.py
+++ b/scripts/save-bucket-captions.py
@@ -1,0 +1,19 @@
+# Downloads caption assets from the GCP bucket into local app's static folder
+import os
+import requests
+
+bucket_name = os.environ["GCP_BUCKET_NAME"]
+
+# GCP bucket files passed in from update-urls.js
+file_array = os.environ["CAPTION_BUCKET_LIST"].split('\n')
+
+file_types = ['.vtt']
+google_prefix = 'https://storage.googleapis.com/'
+
+for filename in file_array:
+  for filetype in file_types:
+    if (filename.find(filetype, 0, 1000) != -1):
+      media_url = google_prefix + bucket_name + '/' + filename
+      print(media_url)
+      r = requests.get(media_url, timeout=10)
+      open('./static/captions/' + filename, 'wb').write(r.content)


### PR DESCRIPTION
The pipedream workflows are configured to save .vtt files to the storage bucket. These scripts provide the option to pull vtt files from a storage bucket to the local dev environment instead of directly from Amara. This can be used as a workaround for default record limits/paginated requests, or just as an alternate way of accessing caption files.